### PR TITLE
Typecasting to type

### DIFF
--- a/src/models/Oauth2Client.php
+++ b/src/models/Oauth2Client.php
@@ -164,7 +164,7 @@ class Oauth2Client extends base\Oauth2Client implements Oauth2ClientInterface
      */
     public function isConfidential()
     {
-        return $this->type !== static::TYPE_PUBLIC;
+        return (int)$this->type !== static::TYPE_PUBLIC;
     }
 
     /**


### PR DESCRIPTION
typecasted the type so the `isConfidential()` function works as intended.

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
