### PR TITLE
Fix $clientSecret passing as true when $client->isConfidential() is false

### DIFF
--- a/src/Oauth2Module.php
+++ b/src/Oauth2Module.php
@@ -1189,6 +1189,8 @@ class Oauth2Module extends Oauth2BaseModule implements BootstrapInterface
             $client = $this->getClientRepository()->findModelByIdentifier($clientIdentifier);
             if ($client && $client->isConfidential()) {
                 $clientSecret = $client->getDecryptedSecret($this->getEncryptor());
+            } else {
+                $clientSecret = null;
             }
         }
 


### PR DESCRIPTION
…alse

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | Fix $clientSecret passing as true when $client->isConfidential() is false
