### PR TITLE
Fix: Migration fails when user.id type is 'bigint'

### DIFF
--- a/src/migrations/Oauth2_00001_CreateOauth2TablesMigration.php
+++ b/src/migrations/Oauth2_00001_CreateOauth2TablesMigration.php
@@ -131,7 +131,8 @@ abstract class Oauth2_00001_CreateOauth2TablesMigration extends Oauth2BaseMigrat
 
         if ($userPkSchema) {
             /** @var ColumnSchemaBuilder $userPkSchemaColumnBuilder */
-            $userPkSchemaColumnBuilder = $this->{$userPkSchema->type}();
+            $type = str_replace('bigint', 'bigInteger', $userPkSchema->type);
+            $userPkSchemaColumnBuilder = $this->{$type}();
         } else {
             $userPkSchemaColumnBuilder = $this->string();
         }


### PR DESCRIPTION
Migration fails as it tries to call bigint() in postgres. Actual method is bigInteger(). So I just did simple replacement for it to work. Not sure if other databases need such replacement as I do not use them

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any
